### PR TITLE
Fix incompatibility with React Native 0.6.0

### DIFF
--- a/RNSwiftSocketIO/SocketBridge.m
+++ b/RNSwiftSocketIO/SocketBridge.m
@@ -15,7 +15,7 @@ RCT_EXTERN_METHOD(addHandlers:(NSDictionary*)handlers)
 RCT_EXTERN_METHOD(connect)
 RCT_EXTERN_METHOD(close:(BOOL)fast)
 RCT_EXTERN_METHOD(reconnect)
-RCT_EXTERN_METHOD(emit:(NSString*)event items:(NSObject*)items)
+RCT_EXTERN_METHOD(emit:(NSString*)event items:(id)items)
 RCT_EXTERN_METHOD(joinNamespace)
 RCT_EXTERN_METHOD(leaveNamespace)
 


### PR DESCRIPTION
Fix incompatibility with React Native 0.6.0 due to missing NSObject in RCTConvert.

This fix recommended by @nicklockwood
https://github.com/facebook/react-native/issues/1746
